### PR TITLE
Embedding into GameCategories responses

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -84,7 +84,8 @@ pub mod users;
 pub mod variables;
 
 pub use client::{AsyncClient, Client, RestClient};
-pub use common::{CategoriesSorting, Direction, VariablesSorting, Root};
+pub use common::{CategoriesSorting, Direction, VariablesSorting};
 pub use error::ApiError;
 pub use pagination::{Pageable, PagedEndpointExt, PagedIter, SinglePage, SinglePageBuilder};
 pub use query::AsyncQuery;
+pub use crate::types::Root;

--- a/src/api.rs
+++ b/src/api.rs
@@ -84,7 +84,7 @@ pub mod users;
 pub mod variables;
 
 pub use client::{AsyncClient, Client, RestClient};
-pub use common::{CategoriesSorting, Direction, VariablesSorting};
+pub use common::{CategoriesSorting, Direction, VariablesSorting, Root};
 pub use error::ApiError;
 pub use pagination::{Pageable, PagedEndpointExt, PagedIter, SinglePage, SinglePageBuilder};
 pub use query::AsyncQuery;

--- a/src/api/common.rs
+++ b/src/api/common.rs
@@ -40,9 +40,9 @@ pub enum CategoriesSorting {
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub(crate) struct Root<T> {
-    pub(crate) data: T,
-    pub(crate) pagination: Option<Pagination>,
+pub struct Root<T> {
+    pub data: T,
+    pub pagination: Option<Pagination>,
 }
 
 impl Default for VariablesSorting {

--- a/src/api/common.rs
+++ b/src/api/common.rs
@@ -38,13 +38,6 @@ pub enum CategoriesSorting {
     Pos,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct Root<T> {
-    pub data: T,
-    pub pagination: Option<Pagination>,
-}
-
 impl Default for VariablesSorting {
     fn default() -> Self {
         Self::Pos

--- a/src/api/endpoint.rs
+++ b/src/api/endpoint.rs
@@ -4,12 +4,12 @@ use async_trait::async_trait;
 use http::{header, Method, Request};
 use log::debug;
 use serde::de::DeserializeOwned;
+use crate::types::Root;
 
 use super::{
-    common::Root,
-    error::BodyError,
-    query::{self, AsyncQuery, Query},
-    ApiError, AsyncClient, Client,
+    ApiError,
+    AsyncClient,
+    Client, error::BodyError, query::{self, AsyncQuery, Query},
 };
 
 pub trait Endpoint {

--- a/src/api/pagination.rs
+++ b/src/api/pagination.rs
@@ -2,14 +2,14 @@ use async_trait::async_trait;
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use http::{header, Request};
 use serde::de::DeserializeOwned;
+use crate::types::Root;
 
 use crate::types::Pagination;
 
 use super::{
-    common::Root,
-    endpoint::Endpoint,
-    query::{self, AsyncQuery, Query},
-    ApiError, AsyncClient, Client, RestClient,
+    ApiError,
+    AsyncClient,
+    Client, endpoint::Endpoint, query::{self, AsyncQuery, Query}, RestClient,
 };
 
 // TODO: Use provided "next" link for pagination

--- a/src/types.rs
+++ b/src/types.rs
@@ -39,7 +39,7 @@ mod variables;
 // TODO: Deserialize dates to chrono types
 
 pub use category::{Category, CategoryType, Players};
-pub use common::{Asset, Assets, Link, ModeratorRole, Names, Pagination, TimingMethod};
+pub use common::{Asset, Assets, Link, ModeratorRole, Names, Pagination, TimingMethod, Root};
 pub use developers::Developer;
 pub use engines::Engine;
 pub use games::{Game, Ruleset};

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -63,3 +63,10 @@ pub struct Names {
     pub japanese: Option<String>,
     pub twitch: Option<String>,
 }
+
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Root<T> {
+    pub data: T,
+    pub pagination: Option<Pagination>,
+}


### PR DESCRIPTION
This has two changes to make this possible:

1. adding the Embed field to GameCategories; you can embed the normal Category embeds here
2. Exposing the `Root<>` type to library users. It's a very convenient way to handle wrapping embeds in custom types used for response deserialization.