### PR TITLE
Parse verify-date into Status objects correctly

### DIFF
--- a/src/types/runs.rs
+++ b/src/types/runs.rs
@@ -57,6 +57,7 @@ pub struct VideoLink {
 #[serde(tag = "status")]
 pub enum Status<'a> {
     New,
+    #[serde(rename_all = "kebab-case")]
     Verified {
         examiner: Option<UserId<'a>>,
         verify_date: Option<String>,


### PR DESCRIPTION
It seems that `#[serde(rename_all = "kebab-case")]` does not apply to nested variants; I was seeing every status from the API parsed as having `None` for `verify_date` without this change.

